### PR TITLE
Passing Knowledge Base Id programmatically

### DIFF
--- a/QnAMakerDialog/QnAMakerDialog.Sample/Controllers/MessagesController.cs
+++ b/QnAMakerDialog/QnAMakerDialog.Sample/Controllers/MessagesController.cs
@@ -13,7 +13,7 @@ namespace QnAMakerDialog.Sample
     {
         internal static IDialog<object> MakeRoot()
         {
-            return Chain.From(() => new Dialogs.QnADialog());
+            return Chain.From(() => new Dialogs.QnADialog("258dbfdd-2470-46ae-ae1f-8a2354d31d80"));
         }
 
         /// <summary>

--- a/QnAMakerDialog/QnAMakerDialog.Sample/Dialogs/QnADialog.cs
+++ b/QnAMakerDialog/QnAMakerDialog.Sample/Dialogs/QnADialog.cs
@@ -5,9 +5,14 @@ using Microsoft.Bot.Builder.Dialogs;
 namespace QnAMakerDialog.Sample.Dialogs
 {
     [Serializable]
-    [QnAMakerService("8f833e867b25443b95d8c23cd367f7ce", "258dbfdd-2470-46ae-ae1f-8a2354d31d80")]
+    [QnAMakerService("8f833e867b25443b95d8c23cd367f7ce", null)]
     public class QnADialog : QnAMakerDialog<object>
     {
+
+        public QnADialog(string knowledgeBaseId) : base(knowledgeBaseId)
+        {
+        }
+
         /// <summary>
         /// Handler used when the QnAMaker finds no appropriate answer
         /// </summary>

--- a/QnAMakerDialog/QnAMakerDialog.Sample/QnAMakerDialog.Sample.csproj
+++ b/QnAMakerDialog/QnAMakerDialog.Sample/QnAMakerDialog.Sample.csproj
@@ -156,7 +156,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>3979</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:3979/</IISUrl>
+          <IISUrl>http://localhost:3989/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/QnAMakerDialog/QnAMakerDialog/QnADialog.cs
+++ b/QnAMakerDialog/QnAMakerDialog/QnADialog.cs
@@ -48,8 +48,18 @@ namespace QnAMakerDialog
     {
         private string _subscriptionKey;
         private string _knowledgeBaseId;
-        public string SubscriptionKey { get => _subscriptionKey; set => _subscriptionKey = value; }
-        public string KnowledgeBaseId { get => _knowledgeBaseId; set => _knowledgeBaseId = value; }
+        public string SubscriptionKey { get { return _subscriptionKey; } set { _subscriptionKey = value; } }            
+        public string KnowledgeBaseId { get { return _knowledgeBaseId; } set { _knowledgeBaseId = value; } }
+
+        public QnAMakerDialog()
+        {
+
+        }
+
+        public QnAMakerDialog(string knowledgeBaseId)
+        {
+            _knowledgeBaseId = knowledgeBaseId;
+        }
 
         [NonSerialized]
         protected Dictionary<QnAMakerResponseHandlerAttribute, QnAMakerResponseHandler> HandlerByMaximumScore;
@@ -266,7 +276,10 @@ namespace QnAMakerDialog
         public QnAMakerServiceAttribute(string subscriptionKey, string knowledgeBaseId)
         {
             SetField.NotNull(out this.subscriptionKey, nameof(subscriptionKey), subscriptionKey);
-            SetField.NotNull(out this.knowledgeBaseId, nameof(knowledgeBaseId), knowledgeBaseId);
+            if (!string.IsNullOrEmpty(knowledgeBaseId))
+            {
+                SetField.NotNull(out this.knowledgeBaseId, nameof(knowledgeBaseId), knowledgeBaseId);
+            }
         }
     }
 


### PR DESCRIPTION
passing the knowledge base id when instantiating the dialog allows the bot to choose a different knowledge base programmatically.